### PR TITLE
Update helm chart to v0.3.1

### DIFF
--- a/charts/spiffe-demo-app/Chart.yaml
+++ b/charts/spiffe-demo-app/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: spiffe-demo-app
 description: A Helm chart to install spiffe-demo-app
 type: application
-version: 0.2.2
-appVersion: 0.1.1
+version: 0.3.1

--- a/charts/spiffe-demo-app/README.md
+++ b/charts/spiffe-demo-app/README.md
@@ -1,6 +1,6 @@
 # spiffe-demo-app
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to install spiffe-demo-app
 
@@ -16,7 +16,7 @@ A Helm chart to install spiffe-demo-app
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"elinesterov/spiffe-demo-app"` | The repository within the registry |
-| image.tag | string | `"v0.2.0"` | The image tag to pull |
+| image.tag | string | `"v0.2.1"` | The image tag to pull |
 | service | object | `{"port":80,"type":"LoadBalancer"}` | The service type to use |
 | spiffeCSIDriver | object | `{"enabled":false}` | SPIFFE CSI driver support |
 | spiffeCSIDriver.enabled | bool | `false` | Enable/disable SPIFFE CSI driver support |

--- a/charts/spiffe-demo-app/values.yaml
+++ b/charts/spiffe-demo-app/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- The repository within the registry
   repository: elinesterov/spiffe-demo-app
   # -- The image tag to pull
-  tag: v0.2.0
+  tag: v0.2.1
   # -- The image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
- update Helm chart to 0.3.1
- image version to v0.2.1
  - support for multiple authorities
  - Display JWT bundle content