### PR TITLE
ability to set busybox image from values

### DIFF
--- a/charts/spiffe-demo-app/templates/deployment.yaml
+++ b/charts/spiffe-demo-app/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- end }}
       {{- if .Values.app.enableBusybox }}
       - name: busybox
-        image: busybox
+        image: {{ .Values.busyboxImage }}
         command: ['sleep', '3600']
         {{- if not .Values.app.spiffeCSIDriverInjectionEnabled }}
         env:

--- a/charts/spiffe-demo-app/values.yaml
+++ b/charts/spiffe-demo-app/values.yaml
@@ -10,6 +10,9 @@ image:
   # -- The image pull policy
   pullPolicy: IfNotPresent
 
+# -- Image used for busybox when enabled
+busyboxImage: busybox
+
 # -- The service type to use
 service:
   type: LoadBalancer


### PR DESCRIPTION
Hi,

Added the ability to set busybox image from values.

```
> helm -n spiffe-demo upgrade spiffe-demo charts/spiffe-demo-app/. --set app.enableBusybox=True --dry-run | grep image
        image: ghcr.io/elinesterov/spiffe-demo-app:v0.2.1
        imagePullPolicy: IfNotPresent
        image: busybox
        imagePullPolicy: IfNotPresent
```

```
> helm -n spiffe-demo upgrade spiffe-demo charts/spiffe-demo-app/. --set app.enableBusybox=True,busyboxImage=some.proxy/busybox --dry-run | grep image
        image: ghcr.io/elinesterov/spiffe-demo-app:v0.2.1
        imagePullPolicy: IfNotPresent
        image: some.proxy/busybox
        imagePullPolicy: IfNotPresent
```