### PR TITLE
add health-check only mode

### DIFF
--- a/charts/spiffe-demo-app/templates/deployment.yaml
+++ b/charts/spiffe-demo-app/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       - name: spiffe-demo-app
         image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.app.healthCheckOnly }}
+        args: ["--health-check-only"]
+        {{- end }}
         {{- if not .Values.app.spiffeCSIDriverInjectionEnabled }}
         env:
           - name: SPIFFE_ENDPOINT_SOCKET

--- a/charts/spiffe-demo-app/values.yaml
+++ b/charts/spiffe-demo-app/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- The repository within the registry
   repository: elinesterov/spiffe-demo-app
   # -- The image tag to pull
-  tag: v0.2.2
+  tag: v0.3.0
   # -- The image pull policy
   pullPolicy: IfNotPresent
 
@@ -32,6 +32,8 @@ app:
   spiffeCSIDriverVolume: false
   # -- Enable busybox container
   enableBusybox: false
+  # -- Enable health check only mode
+  healthCheckOnly: false
 
 # -- SPIFFE CSI driver support
 spiffeCSIDriver:


### PR DESCRIPTION
With this change you can install the helm chart that is running the demo app in the health check only mode. It exposes API endpoint `/api/healthz` which returns 200 OK if the app can get `X.509 SVID`. Other API endpoints are not available in this mode.
This can be useful if you want to have the app in your cluster and expose that endpoint to monitor the health status of the SPIFFE Workload API available in that cluster for all components.