### PR TITLE
Show JWT header in decoded view

### DIFF
--- a/kodata/index.js
+++ b/kodata/index.js
@@ -45,10 +45,33 @@ getJwtButton.addEventListener('click', async () => {
     const decodedHeader = document.createElement('h3');
     decodedHeader.textContent = 'Decoded';
 
+    const base64UrlDecode = (str) => {
+      // Replace base64url chars and pad to a multiple of 4
+      const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+      const padded = base64.padEnd(base64.length + (4 - base64.length % 4) % 4, '=');
+      return atob(padded);
+    };
+
+    const headerLabel = document.createElement('h4');
+    headerLabel.textContent = 'Header';
+    headerLabel.style.marginBottom = '4px';
+
+    const headerText = document.createElement('pre');
+    headerText.classList.add('token');
+    headerText.textContent = JSON.stringify(JSON.parse(base64UrlDecode(token.split('.')[0])), null, 2);
+
+    const payloadLabel = document.createElement('h4');
+    payloadLabel.textContent = 'Payload';
+    payloadLabel.style.marginBottom = '4px';
+
     const decodedText = document.createElement('pre');
     decodedText.classList.add('token');
-    decodedText.textContent = JSON.stringify(JSON.parse(atob(token.split('.')[1])), null, 2);
+    decodedText.textContent = JSON.stringify(JSON.parse(base64UrlDecode(token.split('.')[1])), null, 2);
+
     decodedContainer.appendChild(decodedHeader);
+    decodedContainer.appendChild(headerLabel);
+    decodedContainer.appendChild(headerText);
+    decodedContainer.appendChild(payloadLabel);
     decodedContainer.appendChild(decodedText);
 
     // Add both columns to parsed-cert element


### PR DESCRIPTION
Summary
------------------
Adds the decoded JWT header alongside the existing decoded payload when fetching a JWT SVID, so users can see which key signed the token.

Motivation
------------------
The JWT header contains the key ID (kid) and algorithm (alg) used to sign the SVID, which is useful for debugging and verifying token signing. No Linear ticket.

Tests performed
------------------
Manual testing

Public Release Notes
------------------
- JWT SVID decoded view now shows both the header and payload, including the signing key ID (kid) and algorithm (alg)

Rollback Plan
------------------