### PR TITLE
Decouple image release from chart releases; refresh workflow

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -3,7 +3,7 @@ name: Build and Release the image
 on:
   push:
     tags:
-      - 'spiffe-demo-app-*'
+      - 'v*'
   workflow_dispatch: {}
 
 permissions:
@@ -23,22 +23,15 @@ jobs:
           go-version: '1.25.x'
 
       - name: setup ko
-        uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
+        uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
       
-      - name: Determine image tag
-        id: tag
-        run: |
-          # github.ref_name is the bare tag (e.g. spiffe-demo-app-0.4.3).
-          # Strip the chart/app prefix so the image tag is a clean version (0.4.3).
-          # On manual workflow_dispatch from a branch, fall back to that ref name.
-          tag="${{ github.ref_name }}"
-          tag="${tag#spiffe-demo-app-}"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       - name: build and push
         run: |
+          # Use the bare tag as-is (e.g. v0.3.3) so the image tag matches the
+          # chart's values.yaml convention (tag: vX.Y.Z).
+          tag="${{ github.ref_name }}"
           KO_DOCKER_REPO=ghcr.io/spirl/spiffe-demo-app \
           ko build \
-            --tags ${{ steps.tag.outputs.tag }} \
+            --tags $tag \
             --tag-only \
             --bare


### PR DESCRIPTION
Follow-up to #30, which clears the dependency CVEs but left the image-publish workflow triggering on `spiffe-demo-app-*`.

## Why
`spiffe-demo-app-*` is the tag prefix `chart-releaser` creates for **chart** releases (e.g. `spiffe-demo-app-0.4.2`). With #30's trigger, a chart release would also fire an **image** build and tag the image with the chart's version — coupling two release lines that are meant to be independent (image is on the `0.3.x` line, chart on `0.4.x`).

## Changes
- **Trigger reverted to `v*`** — distinct from chart tags, matches the original convention and the existing `v0.3.2` image. Chart releases no longer rebuild the image.
- **Image tag = bare git tag** (e.g. `v0.3.3`) so it matches the chart's `values.yaml` convention (`tag: vX.Y.Z`).
- **`ko-build/setup-ko` v0.6 → v0.9** (SHA-pinned).

Kept from #30: `go-version: 1.25.x` (required to build the dependency fix), `actions/checkout@v4`, `actions/setup-go@v5`.

## Release process this enables
- **App image:** merge source change → push tag `vX.Y.Z` → builds & pushes `ghcr.io/spirl/spiffe-demo-app:vX.Y.Z`
- **Helm chart (independent):** bump `values.yaml` `image.tag` + `Chart.yaml` `version` → merge to `main` → `chart-releaser` publishes the chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)