### PR TITLE
Remove workflow_dispatch from image workflow

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
The `workflow_dispatch` trigger was added in #31's branch and then removed there, but the removal commit didn't make it into the merge — so it's still on `main`. This drops it, leaving the image workflow triggered solely by `v*` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)