### PR TITLE
Bump chart to 0.4.3, point at image v0.3.3

### DIFF
--- a/charts/spiffe-demo-app/Chart.yaml
+++ b/charts/spiffe-demo-app/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: spiffe-demo-app
 description: A Helm chart to install spiffe-demo-app
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/spiffe-demo-app/README.md
+++ b/charts/spiffe-demo-app/README.md
@@ -20,7 +20,7 @@ A Helm chart to install spiffe-demo-app
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"ghcr.io"` | The OCI registry to pull the image from |
 | image.repository | string | `"spirl/spiffe-demo-app"` | The repository within the registry |
-| image.tag | string | `"v0.3.2"` | The image tag to pull |
+| image.tag | string | `"v0.3.3"` | The image tag to pull |
 | service | object | `{"port":80,"type":"LoadBalancer"}` | The service type to use |
 | spiffeCSIDriver | object | `{"enabled":false}` | SPIFFE CSI driver support |
 | spiffeCSIDriver.enabled | bool | `false` | Enable/disable SPIFFE CSI driver support |

--- a/charts/spiffe-demo-app/values.yaml
+++ b/charts/spiffe-demo-app/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- The repository within the registry
   repository: spirl/spiffe-demo-app
   # -- The image tag to pull
-  tag: v0.3.2
+  tag: v0.3.3
   # -- The image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updates the Helm chart to deploy the security-patched app image **v0.3.3** (built from the dependency fixes in #30/#31 that clear the upstream CVEs tracked in defakto-deploy#35).

## Changes
- `values.yaml`: `image.tag` `v0.3.2` → `v0.3.3`
- `Chart.yaml`: `version` `0.4.2` → `0.4.3` (required for chart-releaser to publish)
- `README.md`: regenerated values table to match

The `v0.3.3` image is confirmed published to `ghcr.io/spirl/spiffe-demo-app`.

On merge to `main`, `release.yml` (chart-releaser) packages and publishes chart `0.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)